### PR TITLE
Adapt plugin to GitBook 3

### DIFF
--- a/index.js
+++ b/index.js
@@ -22,7 +22,7 @@ module.exports = {
             if (page.type === "markdown") {
                 var emojify = require("emojify.js");
                 var emojifyJsConfig = {
-                    img_dir: "/gitbook/plugins/gitbook-plugin-advanced-emoji/emojis/",
+                    img_dir: "gitbook/gitbook-plugin-advanced-emoji/emojis",
                     ignore_emoticons: true,
                     mode: 'img'
                 };


### PR DESCRIPTION
Hello,

We will soon release [GitBook v3](https://github.com/GitbookIO/gitbook).
The plugins API has been updated, as you will see [in the GitBook 3 documentation](http://toolchain.gitbook.com/).

I'm in charge of reviewing the existing plugins for maintaining the compatibility with this new version.
In this version, the plugins files will be places under `gitbook/` instead of `gitbook/plugins/`.

The proposed PR has been tested using GitBook 3.
Let me know if you have any remarks regarding what is done, and don't forget to publish a new version if you merge it, specifying the new engine in your package.json:

``` JSON
"engines": {
    "gitbook": ">=3.0.0-pre.0"
}
```

Kind regards,
Johan
